### PR TITLE
Replace flatnode config only once

### DIFF
--- a/3.7/config.sh
+++ b/3.7/config.sh
@@ -49,4 +49,4 @@ fi
 
 # if flatnode directory was created by volume / mount, use flatnode files
 
-if [ -d "${PROJECT_DIR}/flatnode" ]; then sed -i 's\NOMINATIM_FLATNODE_FILE=\NOMINATIM_FLATNODE_FILE="/nominatim/flatnode/flatnode.file"\g' ${CONFIG_FILE}; fi
+if [ -d "${PROJECT_DIR}/flatnode" ]; then sed -i 's\^NOMINATIM_FLATNODE_FILE=$\NOMINATIM_FLATNODE_FILE="/nominatim/flatnode/flatnode.file"\g' ${CONFIG_FILE}; fi


### PR DESCRIPTION
Fix messing up the flatnode location path when restarting the container.
That in turn breaks the update/replication process.